### PR TITLE
Add persistent storage and rating fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# Instagram
+# Focusing Therapy Interface
+
+This simple Flask application provides a basic interface for patients to take notes during focusing sessions.  Notes are now stored in a local SQLite database.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the application:
+   ```bash
+   python app.py
+   ```
+3. Visit `http://localhost:5000` in your browser. To allow remote access, run the server with the host set to `0.0.0.0` (already configured in `app.py`).
+
+Patients can log in by entering their name. They can then add notes for their focusing sessions, provide optional ratings before and after the session, and review their full history. Data is stored in a SQLite database (`focusing.db`) so it persists across restarts.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,76 @@
+import os
+from datetime import datetime
+from flask import Flask, render_template, request, redirect, url_for, session
+from flask_sqlalchemy import SQLAlchemy
+
+app = Flask(__name__)
+app.secret_key = os.environ.get("SECRET_KEY", "dev")
+app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///focusing.db"
+app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+db = SQLAlchemy(app)
+
+
+class Patient(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(80), nullable=False)
+    notes = db.relationship("SessionNote", backref="patient", lazy=True, order_by="SessionNote.timestamp.desc()")
+
+
+class SessionNote(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    patient_id = db.Column(db.Integer, db.ForeignKey("patient.id"), nullable=False)
+    note = db.Column(db.Text, nullable=False)
+    rating_before = db.Column(db.Integer)
+    rating_after = db.Column(db.Integer)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+with app.app_context():
+    db.create_all()
+
+@app.route('/')
+def index():
+    if 'patient_id' in session:
+        pid = session['patient_id']
+        patient = Patient.query.get(pid)
+        if patient:
+            return render_template('session.html', patient=patient)
+    return render_template('login.html')
+
+@app.route('/login', methods=['POST'])
+def login():
+    name = request.form.get('name')
+    if not name:
+        return redirect(url_for('index'))
+    patient = Patient.query.filter_by(name=name).first()
+    if not patient:
+        patient = Patient(name=name)
+        db.session.add(patient)
+        db.session.commit()
+    session['patient_id'] = patient.id
+    return redirect(url_for('index'))
+
+@app.route('/logout')
+def logout():
+    session.pop('patient_id', None)
+    return redirect(url_for('index'))
+
+@app.route('/add_note', methods=['POST'])
+def add_note():
+    note_text = request.form.get('note')
+    rating_before = request.form.get('rating_before')
+    rating_after = request.form.get('rating_after')
+    pid = session.get('patient_id')
+    if pid and note_text:
+        entry = SessionNote(
+            patient_id=pid,
+            note=note_text,
+            rating_before=int(rating_before) if rating_before else None,
+            rating_after=int(rating_after) if rating_after else None,
+        )
+        db.session.add(entry)
+        db.session.commit()
+    return redirect(url_for('index'))
+
+if __name__ == '__main__':
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/remote_setup_notes.txt
+++ b/remote_setup_notes.txt
@@ -1,0 +1,8 @@
+The application is configured to listen on all network interfaces. To make it accessible remotely:
+
+1. Deploy this folder to a server reachable from the internet.
+2. Ensure Python and the dependencies from `requirements.txt` are installed on that server.
+3. Open the firewall or security group to allow inbound connections on the port used by the app (default 5000).
+4. Run the application with `python app.py` and verify you can reach `http://<server-ip>:5000/` from a remote browser.
+
+Actual deployment (setting up a public server, DNS, HTTPS, etc.) must be performed manually outside of this repository.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask==2.3.2
+Flask-SQLAlchemy==3.0.3

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Focusing Therapy</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        header { margin-bottom: 20px; }
+        .note { border-bottom: 1px solid #ccc; padding: 5px 0; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Focusing Therapy</h1>
+        {% if session.get('patient_id') %}
+            <form action="{{ url_for('logout') }}" method="get" style="display:inline;">
+                <button type="submit">Logout</button>
+            </form>
+        {% endif %}
+    </header>
+    {% block content %}{% endblock %}
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Welcome</h2>
+<form action="{{ url_for('login') }}" method="post">
+    <label for="name">Your Name:</label>
+    <input type="text" id="name" name="name" required>
+    <button type="submit">Start Session</button>
+    <p style="font-size:small;">Use the same name as before to continue your history.</p>
+</form>
+{% endblock %}

--- a/templates/session.html
+++ b/templates/session.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Welcome, {{ patient.name }}</h2>
+<form action="{{ url_for('add_note') }}" method="post">
+    <textarea name="note" rows="4" cols="50" placeholder="Write your notes here" required></textarea><br>
+    <label>Before rating (1-10):
+        <input type="number" name="rating_before" min="1" max="10">
+    </label>
+    <label>After rating (1-10):
+        <input type="number" name="rating_after" min="1" max="10">
+    </label>
+    <button type="submit">Add Note</button>
+</form>
+<h3>Your Notes</h3>
+{% for note in patient.notes %}
+<div class="note">
+    <strong>{{ note.timestamp.strftime('%Y-%m-%d') }}</strong><br>
+    Before: {{ note.rating_before or '-' }} &mdash; After: {{ note.rating_after or '-' }}<br>
+    {{ note.note }}
+</div>
+{% else %}
+<p>No notes yet.</p>
+{% endfor %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- store patient notes in SQLite using SQLAlchemy
- allow rating before and after sessions
- show note history per patient
- document running server for remote access
- provide additional remote deployment instructions

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684324c41b208322bd2cb1a0bbdc6d44