### PR TITLE
Document SECRET_KEY and enforce requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,14 @@ This simple Flask application provides a basic interface for patients to take no
    ```bash
    pip install -r requirements.txt
    ```
-2. Run the application:
+2. Set a `SECRET_KEY` environment variable used by Flask for session security:
+   ```bash
+   export SECRET_KEY="your-secret-value"
+   ```
+3. Run the application:
    ```bash
    python app.py
    ```
-3. Visit `http://localhost:5000` in your browser.
+4. Visit `http://localhost:5000` in your browser.
 
 Patients can log in by entering their name. They can then add notes for their focusing sessions, which appear on the page. The data is stored in memory and will reset when the server restarts.

--- a/app.py
+++ b/app.py
@@ -1,8 +1,12 @@
 import os
 from flask import Flask, render_template, request, redirect, url_for, session
 
+secret_key = os.environ.get("SECRET_KEY")
+if not secret_key:
+    raise RuntimeError("SECRET_KEY environment variable not set")
+
 app = Flask(__name__)
-app.secret_key = os.environ.get("SECRET_KEY", "dev")
+app.secret_key = secret_key
 
 # In-memory storage for simplicity
 patients = {}


### PR DESCRIPTION
## Summary
- document how to set the `SECRET_KEY` environment variable
- require `SECRET_KEY` at runtime

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68433af781888322b72b491585bd0281