### PR TITLE
Add SQLite persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ This simple Flask application provides a basic interface for patients to take no
    ```
 3. Visit `http://localhost:5000` in your browser.
 
-Patients can log in by entering their name. They can then add notes for their focusing sessions, which appear on the page. The data is stored in memory and will reset when the server restarts.
+Patients can log in by entering their name. Notes from their focusing sessions are stored in a local SQLite database (`notes.db`) so data persists across restarts.

--- a/app.py
+++ b/app.py
@@ -1,18 +1,61 @@
 import os
-from flask import Flask, render_template, request, redirect, url_for, session
+import sqlite3
+from flask import Flask, render_template, request, redirect, url_for, session, g
 
 app = Flask(__name__)
 app.secret_key = os.environ.get("SECRET_KEY", "dev")
 
-# In-memory storage for simplicity
-patients = {}
+DATABASE = os.path.join(os.path.dirname(__file__), "notes.db")
+
+
+def get_db():
+    if 'db' not in g:
+        conn = sqlite3.connect(DATABASE)
+        conn.row_factory = sqlite3.Row
+        g.db = conn
+    return g.db
+
+
+@app.teardown_appcontext
+def close_db(exc):
+    db = g.pop('db', None)
+    if db is not None:
+        db.close()
+
+
+def init_db():
+    db = get_db()
+    db.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS patients (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS notes (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            patient_id INTEGER NOT NULL,
+            note TEXT NOT NULL,
+            FOREIGN KEY(patient_id) REFERENCES patients(id)
+        );
+        """
+    )
+    db.commit()
 
 @app.route('/')
 def index():
     if 'patient_id' in session:
         pid = session['patient_id']
-        patient = patients.get(pid)
-        return render_template('session.html', patient=patient)
+        db = get_db()
+        patient = db.execute('SELECT id, name FROM patients WHERE id=?', (pid,)).fetchone()
+        if patient:
+            notes = db.execute('SELECT note FROM notes WHERE patient_id=?', (pid,)).fetchall()
+            patient_data = {
+                "id": patient["id"],
+                "name": patient["name"],
+                "notes": [n["note"] for n in notes]
+            }
+            return render_template('session.html', patient=patient_data)
     return render_template('login.html')
 
 @app.route('/login', methods=['POST'])
@@ -20,8 +63,10 @@ def login():
     name = request.form.get('name')
     if not name:
         return redirect(url_for('index'))
-    pid = len(patients) + 1
-    patients[pid] = {"id": pid, "name": name, "notes": []}
+    db = get_db()
+    cur = db.execute('INSERT INTO patients (name) VALUES (?)', (name,))
+    db.commit()
+    pid = cur.lastrowid
     session['patient_id'] = pid
     return redirect(url_for('index'))
 
@@ -35,8 +80,12 @@ def add_note():
     note = request.form.get('note')
     pid = session.get('patient_id')
     if pid and note:
-        patients[pid]['notes'].append(note)
+        db = get_db()
+        db.execute('INSERT INTO notes (patient_id, note) VALUES (?, ?)', (pid, note))
+        db.commit()
     return redirect(url_for('index'))
 
 if __name__ == '__main__':
+    with app.app_context():
+        init_db()
     app.run(debug=True)


### PR DESCRIPTION
## Summary
- persist login and note information in a new `notes.db` SQLite database
- manage a single connection per request and initialize tables automatically
- document persistent storage in `README`

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68433b030df8832289e503cd1df2537b