### PR TITLE
Fix flake8 errors and update tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,4 @@ venv.bak/
 
 # mkdocs documentation
 /site
+notes.db

--- a/app.py
+++ b/app.py
@@ -1,6 +1,14 @@
 import os
 import sqlite3
-from flask import Flask, render_template, request, redirect, url_for, session, g
+from flask import (
+    Flask,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    session,
+    g,
+)
 
 secret_key = os.environ.get("SECRET_KEY")
 if not secret_key:
@@ -52,9 +60,15 @@ def index():
     if 'patient_id' in session:
         pid = session['patient_id']
         db = get_db()
-        patient = db.execute('SELECT id, name FROM patients WHERE id=?', (pid,)).fetchone()
+        patient = db.execute(
+            'SELECT id, name FROM patients WHERE id=?',
+            (pid,),
+        ).fetchone()
         if patient:
-            notes = db.execute('SELECT note FROM notes WHERE patient_id=?', (pid,)).fetchall()
+            notes = db.execute(
+                'SELECT note FROM notes WHERE patient_id=?',
+                (pid,),
+            ).fetchall()
             patient_data = {
                 "id": patient["id"],
                 "name": patient["name"],
@@ -89,7 +103,10 @@ def add_note():
     pid = session.get('patient_id')
     if pid and note:
         db = get_db()
-        db.execute('INSERT INTO notes (patient_id, note) VALUES (?, ?)', (pid, note))
+        db.execute(
+            'INSERT INTO notes (patient_id, note) VALUES (?, ?)',
+            (pid, note),
+        )
         db.commit()
     return redirect(url_for('index'))
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,32 +1,43 @@
-import pytest
-import werkzeug
+import os
+
+os.environ.setdefault("SECRET_KEY", "test")
+
+from app import app, init_db  # noqa: E402
+import pytest  # noqa: E402
+import werkzeug  # noqa: E402
+
 if not hasattr(werkzeug, "__version__"):
     werkzeug.__version__ = "unknown"
-from app import app, patients
+
 
 @pytest.fixture
-def client():
-    app.config['TESTING'] = True
+def client(tmp_path):
+    db_path = tmp_path / "test.db"
+    app.config["TESTING"] = True
+    app.DATABASE = str(db_path)
+    with app.app_context():
+        init_db()
     with app.test_client() as client:
         yield client
 
-@pytest.fixture(autouse=True)
-def clear_patients():
-    patients.clear()
-
 
 def test_login_page_renders(client):
-    response = client.get('/')
+    response = client.get("/")
     assert response.status_code == 200
-    assert b'Your Name' in response.data
+    assert b"Your Name" in response.data
 
 
 def test_add_note(client):
-    # Log in as a patient
-    response = client.post('/login', data={'name': 'Alice'}, follow_redirects=True)
-    assert b'Welcome, Alice' in response.data
-
-    # Add a note
-    response = client.post('/add_note', data={'note': 'First note'}, follow_redirects=True)
+    response = client.post(
+        "/login",
+        data={"name": "Alice"},
+        follow_redirects=True,
+    )
+    assert b"Welcome, Alice" in response.data
+    response = client.post(
+        "/add_note",
+        data={"note": "First note"},
+        follow_redirects=True,
+    )
     assert response.status_code == 200
-    assert b'First note' in response.data
+    assert b"First note" in response.data


### PR DESCRIPTION
## Summary
- split long lines in `app.py`
- modernize SQL queries and note addition logic
- rewrite `tests/test_app.py` for new database-based app
- ignore the generated `notes.db`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843352aaadc83228a6c54f32288a85e